### PR TITLE
Update .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
             "error",
             "single"
         ],
-        "@typescript-eslint/explicit-function-return-type": "off"
+        "@typescript-eslint/explicit-function-return-type": "off",
+        "prettier/prettier": "error"
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,18 +11,6 @@
         "sourceType": "module"
     },
     "rules": {
-        "indent": [
-            "error",
-            4
-        ],
-        "semi": [
-            "error",
-            "always"
-        ],
-        "quotes": [
-            "error",
-            "single"
-        ],
         "@typescript-eslint/explicit-function-return-type": "off",
         "prettier/prettier": "error"
     }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,7 @@
         "prettier/@typescript-eslint",
         "plugin:prettier/recommended"
     ],
-    "plugins": "@typescript-eslint",
+    "plugins": ["@typescript-eslint"],
     "parserOptions": {
         "ecmaVersion": 2019,
         "sourceType": "module"


### PR DESCRIPTION
ESLint: ESLint configuration in .eslintrc.json » eslint-config-typicalbot is invalid: - Property "plugins" is the wrong type (expected array but got `"@typescript-eslint"`).  Please see the 'ESLint' output channel for details.